### PR TITLE
Reduce dependabot frequency.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "cron"
+      cronjob: "0 9 * * mon%2"
     groups:
       dev-deps:
         dependency-type: development
@@ -21,9 +20,8 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "cron"
+      cronjob: "0 9 * * mon%2"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "terraform"
@@ -33,9 +31,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "cron"
+      cronjob: "0 9 * * mon%2"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "cron"
-      cronjob: "0 9 * * mon%2"
+      interval: "monthly"
+      time: "09:00"
     groups:
       dev-deps:
         dependency-type: development
@@ -20,8 +20,8 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:
-      interval: "cron"
-      cronjob: "0 9 * * mon%2"
+      interval: "monthly"
+      time: "09:00"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "terraform"
@@ -31,8 +31,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "cron"
-      cronjob: "0 9 * * mon%2"
+      interval: "monthly"
+      time: "09:00"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "actions"


### PR DESCRIPTION
We don't really need this to run every week. Currently dropping to every 2 weeks, and might drop it to monthly in the future.

EDIT: switched to monthly due to uncertainty in the supported cron options for dependabot.

Assisted-by: Codex.app:GPT-5.6-Sol